### PR TITLE
fix(build): add py-modules to fix uvx/pip install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
 fathom-mcp = "server:main"
 
 [tool.setuptools]
+py-modules = ["server", "config", "utils", "fathom_client"]
 package-dir = {"" = "."}
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Summary

- Adds `py-modules` to `pyproject.toml` to include root-level modules in the built package

The `setuptools.packages.find` directive only discovers Python packages (directories with `__init__.py`), not standalone `.py` modules. This caused the entry point `server:main` to fail with `ModuleNotFoundError: No module named 'server'` when installed via:

```
uvx --from git+https://github.com/druellan/Fathom-Simple-MCP.git fathom-mcp
```

Adding `py-modules` explicitly includes `server.py`, `config.py`, `utils.py`, and `fathom_client.py` in the built package.

## Test plan

- [x] Run `uvx --from git+https://github.com/ajorg/Fathom-Simple-MCP.git@fix/py-modules-packaging fathom-mcp` and verify it starts without `ModuleNotFoundError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)