### PR TITLE
Pin fastmcp to 2.x to prevent breaking upgrade

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Operating System :: OS Independent"
 ]
 dependencies = [
-    "fastmcp>=2.12.3",
+    "fastmcp>=2.12.3,<3",
     "httpx>=0.28.1",
     "python-toon>=0.1.0",
     "strip-markdown>=1.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fastmcp>=2.12.3
+fastmcp>=2.12.3,<3
 httpx>=0.28.1
 python-toon>=0.1.0
 strip_markdown>=1.0.0

--- a/uv.lock
+++ b/uv.lock
@@ -429,7 +429,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastmcp", specifier = ">=2.12.3" },
+    { name = "fastmcp", specifier = ">=2.12.3,<3" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "python-toon", specifier = ">=0.1.0" },
     { name = "strip-markdown", specifier = ">=1.0.0" },


### PR DESCRIPTION
## Summary

- Pin `fastmcp` to `>=2.12.3,<3` in `pyproject.toml` and `requirements.txt`
- Regenerate `uv.lock` to match

## Why

FastMCP 3.0 removed the `tool_serializer` kwarg used in `server.py`, causing an immediate startup failure when `uv` resolves to 3.x (e.g. via `uv tool upgrade --all`).

## What changed

Two-line version constraint change + lockfile sync. No code changes.

## Risk

None — this just prevents an unintentional upgrade to an incompatible major version.

Relates to #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)