### PR TITLE
fix: make get_meeting metadata best-effort to support older / other-recorder recording IDs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ package-dir = {"" = "."}
 
 [tool.setuptools.packages.find]
 where = ["."]
+exclude = ["tests*"]
 
 [tool.commitizen]
 name = "cz_conventional_commits"

--- a/tests/test_recordings.py
+++ b/tests/test_recordings.py
@@ -1,0 +1,190 @@
+"""Unit tests for tools/recordings.py.
+
+These tests cover the resilience behavior introduced for `get_meeting_transcript`
+and `get_meeting_details`: when `client.get_meeting` raises (the Fathom REST API
+has no `GET /recordings/{id}` endpoint, so older recordings 404 against the
+first-page scan), the transcript/summary calls still succeed and metadata fields
+come back empty.
+
+Run with:
+    uv run python -m unittest tests.test_recordings
+"""
+import os
+import sys
+import unittest
+from unittest.mock import AsyncMock, patch
+
+# Set a dummy API key before importing the module under test so config validation
+# doesn't fail at import time.
+os.environ.setdefault("FATHOM_API_KEY", "test-key")
+
+# Make the package root importable when running from a checkout.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from fathom_client import FathomAPIError  # noqa: E402
+from tools import recordings  # noqa: E402
+
+
+class MockContext:
+    """Minimal stand-in for fastmcp.Context — only info/error are called."""
+
+    def __init__(self):
+        self.info_messages = []
+        self.error_messages = []
+
+    async def info(self, msg):
+        self.info_messages.append(msg)
+
+    async def error(self, msg):
+        self.error_messages.append(msg)
+
+
+SAMPLE_MEETING = {
+    "title": "1-1 alice - bob",
+    "url": "https://fathom.video/calls/12345",
+    "share_url": "https://fathom.video/share/abcdef",
+    "created_at": "2026-05-27T14:30:00Z",
+    "scheduled_start_time": "2026-05-27T14:30:00Z",
+    "scheduled_end_time": "2026-05-27T15:00:00Z",
+    "recording_start_time": "2026-05-27T14:30:30Z",
+    "recording_end_time": "2026-05-27T15:00:45Z",
+    "transcript_language": "en",
+    "participants": [{"name": "Alice"}, {"name": "Bob"}],
+    "recorded_by": {"name": "Alice", "email": "alice@example.com"},
+    "teams": ["Engineering"],
+    "topics": ["1-1"],
+    "sentiment": "neutral",
+    "crm_matches": [],
+}
+
+SAMPLE_TRANSCRIPT = {
+    "transcript": [
+        {"speaker": {"display_name": "Alice"}, "text": "Hi Bob.", "timestamp": "00:00:01"},
+        {"speaker": {"display_name": "Bob"}, "text": "Hey Alice.", "timestamp": "00:00:03"},
+    ]
+}
+
+SAMPLE_SUMMARY = {
+    "summary": {
+        "markdown_formatted": "## Recap\n\nAlice and Bob caught up.",
+    }
+}
+
+
+class GetMeetingTranscriptTests(unittest.IsolatedAsyncioTestCase):
+    """Behavior of get_meeting_transcript across meeting-lookup outcomes."""
+
+    async def test_returns_transcript_with_full_metadata_when_meeting_lookup_succeeds(self):
+        with patch.object(recordings.client, "get_meeting", new=AsyncMock(return_value=SAMPLE_MEETING)), \
+             patch.object(recordings.client, "get_transcript", new=AsyncMock(return_value=SAMPLE_TRANSCRIPT)):
+            result = await recordings.get_meeting_transcript(MockContext(), recording_id=12345)
+
+        self.assertEqual(result["recording_id"], 12345)
+        self.assertEqual(result["title"], "1-1 alice - bob")
+        self.assertEqual(len(result["participants"]), 2)
+        self.assertEqual(result["created_at"], "2026-05-27T14:30:00Z")
+        self.assertEqual(len(result["transcript"]), 2)
+
+    async def test_returns_transcript_with_empty_metadata_when_meeting_lookup_404s(self):
+        """The fix: a 404 from get_meeting must not fail the whole call."""
+        meeting_404 = FathomAPIError("Meeting with recording_id 99999 not found", 404)
+        with patch.object(recordings.client, "get_meeting", new=AsyncMock(side_effect=meeting_404)), \
+             patch.object(recordings.client, "get_transcript", new=AsyncMock(return_value=SAMPLE_TRANSCRIPT)):
+            ctx = MockContext()
+            result = await recordings.get_meeting_transcript(ctx, recording_id=99999)
+
+        # Transcript still comes through.
+        self.assertEqual(result["recording_id"], 99999)
+        self.assertEqual(len(result["transcript"]), 2)
+        # Metadata fields come back empty (not raised).
+        self.assertIsNone(result["title"])
+        self.assertEqual(result["participants"], [])
+        self.assertIsNone(result["created_at"])
+        self.assertIsNone(result["scheduled_start_time"])
+        self.assertIsNone(result["scheduled_end_time"])
+        # Best-effort log includes exception type + status so operators can
+        # distinguish 401 (scope change / bad key) from 404 (old recording).
+        self.assertTrue(any("Meeting metadata not available" in m for m in ctx.info_messages))
+        self.assertTrue(any("FathomAPIError status=404" in m for m in ctx.info_messages))
+
+    async def test_propagates_when_meeting_lookup_raises_non_fathom_exception(self):
+        """Non-FathomAPIError exceptions on the meeting lookup are NOT swallowed.
+
+        A KeyError/AttributeError/etc. from a programming bug must propagate so
+        it can be diagnosed, not get silently hidden as "metadata unavailable."
+        """
+        with patch.object(recordings.client, "get_meeting", new=AsyncMock(side_effect=RuntimeError("boom"))), \
+             patch.object(recordings.client, "get_transcript", new=AsyncMock(return_value=SAMPLE_TRANSCRIPT)):
+            with self.assertRaises(RuntimeError):
+                await recordings.get_meeting_transcript(MockContext(), recording_id=12345)
+
+    async def test_raises_when_transcript_fetch_fails(self):
+        """Transcript is the primary payload; its failure must propagate."""
+        transcript_err = FathomAPIError("Resource not found", 404)
+        with patch.object(recordings.client, "get_meeting", new=AsyncMock(return_value=SAMPLE_MEETING)), \
+             patch.object(recordings.client, "get_transcript", new=AsyncMock(side_effect=transcript_err)):
+            with self.assertRaises(FathomAPIError):
+                await recordings.get_meeting_transcript(MockContext(), recording_id=12345)
+
+    async def test_raises_when_transcript_fetch_fails_even_if_meeting_also_fails(self):
+        """If both fail, the transcript error is what propagates (the primary payload)."""
+        with patch.object(recordings.client, "get_meeting", new=AsyncMock(side_effect=FathomAPIError("meet-404", 404))), \
+             patch.object(recordings.client, "get_transcript", new=AsyncMock(side_effect=FathomAPIError("transcript-404", 404))):
+            with self.assertRaises(FathomAPIError) as cm:
+                await recordings.get_meeting_transcript(MockContext(), recording_id=12345)
+        self.assertEqual(cm.exception.message, "transcript-404")
+
+
+class GetMeetingDetailsTests(unittest.IsolatedAsyncioTestCase):
+    """Behavior of get_meeting_details across meeting-lookup outcomes."""
+
+    async def test_returns_summary_with_full_metadata_when_meeting_lookup_succeeds(self):
+        with patch.object(recordings.client, "get_meeting", new=AsyncMock(return_value=SAMPLE_MEETING)), \
+             patch.object(recordings.client, "get_summary", new=AsyncMock(return_value=SAMPLE_SUMMARY)):
+            result = await recordings.get_meeting_details(MockContext(), recording_id=12345)
+
+        self.assertEqual(result["recording_id"], 12345)
+        self.assertEqual(result["title"], "1-1 alice - bob")
+        self.assertIn("Alice and Bob caught up", result["summary"])
+
+    async def test_returns_summary_with_empty_metadata_when_meeting_lookup_404s(self):
+        """The fix: a 404 from get_meeting must not fail the whole call."""
+        meeting_404 = FathomAPIError("Meeting with recording_id 99999 not found", 404)
+        with patch.object(recordings.client, "get_meeting", new=AsyncMock(side_effect=meeting_404)), \
+             patch.object(recordings.client, "get_summary", new=AsyncMock(return_value=SAMPLE_SUMMARY)):
+            ctx = MockContext()
+            result = await recordings.get_meeting_details(ctx, recording_id=99999)
+
+        self.assertEqual(result["recording_id"], 99999)
+        self.assertIn("Alice and Bob caught up", result["summary"])
+        # Scalar metadata fields come back None.
+        self.assertIsNone(result["title"])
+        self.assertIsNone(result["meeting_url"])
+        self.assertIsNone(result["recorded_by"])
+        # List-typed metadata fields come back as empty lists, not None, so
+        # downstream callers can iterate without a None check.
+        self.assertEqual(result["participants"], [])
+        self.assertEqual(result["teams"], [])
+        self.assertEqual(result["topics"], [])
+        self.assertEqual(result["crm_matches"], [])
+        # Best-effort log includes exception type + status for operator triage.
+        self.assertTrue(any("Meeting metadata not available" in m for m in ctx.info_messages))
+        self.assertTrue(any("FathomAPIError status=404" in m for m in ctx.info_messages))
+
+    async def test_propagates_when_meeting_lookup_raises_non_fathom_exception(self):
+        """Non-FathomAPIError exceptions on the meeting lookup are NOT swallowed."""
+        with patch.object(recordings.client, "get_meeting", new=AsyncMock(side_effect=RuntimeError("boom"))), \
+             patch.object(recordings.client, "get_summary", new=AsyncMock(return_value=SAMPLE_SUMMARY)):
+            with self.assertRaises(RuntimeError):
+                await recordings.get_meeting_details(MockContext(), recording_id=12345)
+
+    async def test_raises_when_summary_fetch_fails(self):
+        """Summary is the primary payload for get_meeting_details; its failure must propagate."""
+        with patch.object(recordings.client, "get_meeting", new=AsyncMock(return_value=SAMPLE_MEETING)), \
+             patch.object(recordings.client, "get_summary", new=AsyncMock(side_effect=FathomAPIError("nope", 404))):
+            with self.assertRaises(FathomAPIError):
+                await recordings.get_meeting_details(MockContext(), recording_id=12345)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/recordings.py
+++ b/tools/recordings.py
@@ -11,6 +11,15 @@ async def get_meeting_details(
 ) -> dict:
     """Retrieve comprehensive meeting details including summary and metadata (without transcript).
 
+    Meeting metadata is best-effort. The Fathom REST API has no GET /recordings/{id}
+    endpoint, so `client.get_meeting` falls back to scanning the first page of
+    /meetings. The metadata lookup will miss for recordings older than that first
+    page, and also for recordings the authenticated user did not personally record
+    (those are not surfaced on /meetings under the user's API key). When the
+    metadata lookup misses, the summary is still returned with empty metadata
+    fields. Programming errors (non-FathomAPIError exceptions) on the metadata
+    lookup are not swallowed — they propagate.
+
     Args:
         ctx: MCP context for logging
         recording_id: Numeric ID of the recording
@@ -21,11 +30,37 @@ async def get_meeting_details(
     try:
         await ctx.info(f"Fetching meeting details for recording {recording_id}")
 
-        # Fetch meeting metadata and summary concurrently
-        meeting_task = client.get_meeting(recording_id)
-        summary_task = client.get_summary(recording_id)
+        # Fetch meeting metadata (best-effort) and summary concurrently.
+        # The summary endpoint is direct (/recordings/{id}/summary) and works for
+        # any recording_id; the meeting lookup may 404 for older recordings or
+        # for recordings the user did not personally record.
+        results = await asyncio.gather(
+            client.get_meeting(recording_id),
+            client.get_summary(recording_id),
+            return_exceptions=True,
+        )
+        meeting_result, summary_result = results
 
-        meeting, summary = await asyncio.gather(meeting_task, summary_task)
+        # Summary is the primary payload; fail if it errored.
+        if isinstance(summary_result, Exception):
+            raise summary_result
+        summary = summary_result
+
+        # Meeting metadata is optional. Only API errors are treated as "not
+        # available"; other exception types are likely programming bugs and
+        # should propagate.
+        if isinstance(meeting_result, FathomAPIError):
+            status = getattr(meeting_result, "status_code", "?")
+            await ctx.info(
+                f"Meeting metadata not available for {recording_id} "
+                f"(FathomAPIError status={status}); "
+                f"returning summary with empty metadata fields."
+            )
+            meeting = {}
+        elif isinstance(meeting_result, Exception):
+            raise meeting_result
+        else:
+            meeting = meeting_result
 
         # Convert markdown summary to plain text
         markdown_summary = summary.get("summary", {}).get("markdown_formatted", "")
@@ -57,10 +92,10 @@ async def get_meeting_details(
 
     except FathomAPIError as e:
         await ctx.error(f"Fathom API error: {e.message}")
-        raise e
+        raise
     except Exception as e:
         await ctx.error(f"Unexpected error fetching meeting details: {str(e)}")
-        raise e
+        raise
 
 
 async def get_meeting_transcript(
@@ -68,6 +103,15 @@ async def get_meeting_transcript(
     recording_id: int
 ) -> dict:
     """Retrieve meeting transcript with essential metadata.
+
+    Meeting metadata is best-effort. The Fathom REST API has no GET /recordings/{id}
+    endpoint, so `client.get_meeting` falls back to scanning the first page of
+    /meetings. The metadata lookup will miss for recordings older than that first
+    page, and also for recordings the authenticated user did not personally record
+    (those are not surfaced on /meetings under the user's API key). When the
+    metadata lookup misses, the transcript is still returned with empty metadata
+    fields. Programming errors (non-FathomAPIError exceptions) on the metadata
+    lookup are not swallowed — they propagate.
 
     Args:
         ctx: MCP context for logging
@@ -79,12 +123,38 @@ async def get_meeting_transcript(
     try:
         await ctx.info(f"Fetching transcript for recording {recording_id}")
 
-        # Fetch meeting metadata and transcript concurrently
-        meeting_task = client.get_meeting(recording_id)
-        transcript_task = client.get_transcript(recording_id)
+        # Fetch meeting metadata (best-effort) and transcript concurrently.
+        # The transcript endpoint is direct (/recordings/{id}/transcript) and works
+        # for any recording_id; the meeting lookup may 404 for older recordings or
+        # for recordings the user did not personally record.
+        results = await asyncio.gather(
+            client.get_meeting(recording_id),
+            client.get_transcript(recording_id),
+            return_exceptions=True,
+        )
+        meeting_result, transcript_result = results
 
-        meeting, transcript = await asyncio.gather(meeting_task, transcript_task)
-        
+        # Transcript is the primary payload; fail if it errored.
+        if isinstance(transcript_result, Exception):
+            raise transcript_result
+        transcript = transcript_result
+
+        # Meeting metadata is optional. Only API errors are treated as "not
+        # available"; other exception types are likely programming bugs and
+        # should propagate.
+        if isinstance(meeting_result, FathomAPIError):
+            status = getattr(meeting_result, "status_code", "?")
+            await ctx.info(
+                f"Meeting metadata not available for {recording_id} "
+                f"(FathomAPIError status={status}); "
+                f"returning transcript with empty metadata fields."
+            )
+            meeting = {}
+        elif isinstance(meeting_result, Exception):
+            raise meeting_result
+        else:
+            meeting = meeting_result
+
         # Build transcript object with essential metadata
         result = {
             "recording_id": recording_id,
@@ -101,7 +171,7 @@ async def get_meeting_transcript(
 
     except FathomAPIError as e:
         await ctx.error(f"Fathom API error: {e.message}")
-        raise e
+        raise
     except Exception as e:
         await ctx.error(f"Unexpected error fetching meeting transcript: {str(e)}")
-        raise e
+        raise


### PR DESCRIPTION
## Problem

`get_meeting_transcript(recording_id)` and `get_meeting_details(recording_id)` fail with 404 in two common cases, even though the underlying transcript/summary endpoints work fine for those recordings:

1. **Recordings older than the first page of `/meetings`**
2. **Recordings the authenticated user did not personally record** (those aren't surfaced on `/meetings` under the user's API key)

Reproduced against the live Fathom API:
- An older recording ID via `get_meeting_transcript`: raises `FathomAPIError: Meeting with recording_id <id> not found, 404`
- Same ID via `GET /recordings/<id>/transcript` directly: returns the valid transcript

## Root cause

`client.get_meeting(recording_id)` (`fathom_client.py:68-79`) lists `/meetings` without pagination and scans only the first page. If the ID isn't on that page, it raises `FathomAPIError(404)`.

`get_meeting_transcript` and `get_meeting_details` then use `asyncio.gather(meeting_task, transcript_task)`, which propagates the exception and fails the whole call.

## Fix

Use `return_exceptions=True` on the `gather` and treat meeting metadata as best-effort. The transcript/summary stays the primary payload; metadata fields come back empty when the lookup misses.

**Important narrowing**: only `FathomAPIError` from the metadata call is treated as "metadata unavailable." Other exception types (programming bugs, unexpected network errors) propagate so they remain diagnosable.

**Operator-friendly logging**: the best-effort log line includes the exception's status code (e.g., `FathomAPIError status=404`) so operators can distinguish a normal 404 (recording not on page 1) from a 401 (scope/key issue) without re-running with debug logging.

## Why not paginate `get_meeting`?

The Fathom REST API has no `GET /recordings/{id}` endpoint (confirmed via `developers.fathom.ai/llms.txt` — surface is `/meetings`, `/recordings/{id}/summary`, `/recordings/{id}/transcript`, `/teams`, `/team-members`, `/webhooks`). To reliably find any recording, `get_meeting` would have to walk every page of `/meetings` — slow and rate-limit-hostile.

Callers that need full metadata for older or other-recorder recordings can use `list_meetings` with `created_after`/`cursor` filters scoped to the time range they care about.

## Tests

Adds 9 unit tests in `tests/test_recordings.py` using `unittest.IsolatedAsyncioTestCase` + `unittest.mock` — no live API or API key required. Tests cover:
- Full-metadata happy path (both endpoints succeed)
- 404 from `get_meeting` → best-effort behavior, transcript/summary still returned
- Non-`FathomAPIError` exception on metadata lookup → propagates (NOT swallowed)
- Primary-payload (transcript/summary) failure → propagates with original error
- Both-fail → transcript/summary error propagates (the primary)
- List-typed metadata fields default to `[]` (not `None`) so downstream callers can iterate safely
- Best-effort log includes the exception type + status code

Run:
```
uv run python -m unittest tests.test_recordings -v
```

Tests are excluded from the built wheel via `[tool.setuptools.packages.find]` `exclude = ["tests*"]`.

## Test plan

- [x] `python3 -m py_compile tools/recordings.py` — clean
- [x] All 9 unit tests pass
- [x] Live-API smoke test: an older recording ID now returns its transcript with empty metadata (previously raised 404); a recent recording still works normally